### PR TITLE
unattended installation WIP

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1719,7 +1719,7 @@ function OSCheckUnattended() {
 
 # parse command line parameters
 
-config_keys = "db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd comp_id your_company installation_key relative_path new_web_dir web_user";
+config_keys="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd your_company installation_key relative_path new_web_dir" 
 
 while [[ $# -gt 0 ]]; do
 	key="$1"
@@ -1735,7 +1735,7 @@ while [[ $# -gt 0 ]]; do
 			;;
 		*)
 			for var in $config_keys; do
-				if [[ "--$(echo $var | sed 's,_,-,')" == "$key" ]]; then
+				if [[ "--$(echo $var | sed 's,_,-,g')" == "$key" ]]; then
 					eval $var=\"$1\"
 					shift
 					break
@@ -1746,14 +1746,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$UNATTENDED" = "YES" ]; then
-	OSCheckUnattended
-	dbConnTest root
-	[[ "$dbConnx" == "yes" ]] || { echo "Could not connect to the database."; exit 1; }
 	case $ACTION in
 		INSTALL)
 			for var in $config_keys; do
-				[[ -z ${$var} ]] && { echo "Parameter --$(echo $var | sed 's,_,-,') was required but not set"; exit 1; }
+				[[ -z "$(eval echo \$$var)" ]] && { echo "Parameter --$(echo $var | sed 's,_,-,g') was required but not set"; exit 1; }
 			done
+			OSCheckUnattended
+			dbConnTest root
+			[[ "$dbConnx" == "yes" ]] || { echo "Could not connect to the database."; exit 1; }
 		
 			dbUserDBCreate
 			dbConnTest

--- a/install.sh
+++ b/install.sh
@@ -1716,7 +1716,7 @@ function OSCheckUnattended() {
 
 # parse command line parameters
 
-config_keys="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd your_company installation_key relative_path new_web_dir web_user" 
+config_keys="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email new_web_admin_passwd new_web_duser new_web_duser_email new_web_duser_passwd your_company installation_key relative_path new_web_dir web_user" 
 
 while [[ $# -gt 0 ]]; do
 	key="$1"

--- a/install.sh
+++ b/install.sh
@@ -1302,7 +1302,8 @@ if [[ -f /etc/apache2/conf.d/patch_manager.conf ]]; then
 	rm -f /etc/apache2/conf.d/patch_manager.conf
 fi
 # setup virtualhost
-cat <<EOA > /etc/apache2/conf.d/patch_manager.conf
+[ -d "/etc/apache2/conf-available" ] && confdir="/etc/apache2/conf-available" || confdir="/etc/apache2/conf.d"
+cat <<EOA > $confdir/patch_manager.conf
 Alias $patchmgr $targetdir
 CustomLog /var/log/apache2/patch_manager/${host_node}_access.log common
 ErrorLog /var/log/apache2/patch_manager/${host_node}_error.log
@@ -1314,6 +1315,8 @@ ErrorLog /var/log/apache2/patch_manager/${host_node}_error.log
         Allow from all
 </Directory>
 EOA
+
+[ -d "/etc/apache2/conf-available" ] && a2enconf patch_manager
 
 elif [[ "$os" = "CentOS" ]] || [[ "$os" = "Fedora" ]] || [[ "$os" = "Red Hat" ]] || [[ "$os" = "Red Hat Enterprise" ]]; then
 # create log dir and set perms

--- a/install.sh
+++ b/install.sh
@@ -1716,7 +1716,7 @@ function OSCheckUnattended() {
 
 # parse command line parameters
 
-config_keys="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd your_company installation_key relative_path new_web_dir" 
+config_keys="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd your_company installation_key relative_path new_web_dir web_user" 
 
 while [[ $# -gt 0 ]]; do
 	key="$1"

--- a/install.sh
+++ b/install.sh
@@ -1735,7 +1735,7 @@ while [[ $# -gt 0 ]]; do
 			;;
 		*)
 			for var in $config_keys; do
-				if [[ "$var" == "$key" ]]; then
+				if [[ "--$(echo $var | sed 's,_,-,')" == "$key" ]]; then
 					eval $var=\"$1\"
 					shift
 					break

--- a/install.sh
+++ b/install.sh
@@ -1282,8 +1282,8 @@ DB_PASS='$db_pass'
 DB_NAME='$db_name'"
 
 # remove ending forward slash for conf
-patchmgr=$(echo $relative_path|sed 's=/[^/]*$==;s/\.$//')
-targetdir=$(echo $new_web_dir|sed 's=/[^/]*$==;s/\.$//')
+patchmgr=${relative_path%/}
+targetdir=${new_web_dir%/}
 
 # install virtualhost file to default conf.d dir apache/httpd
 if [[ "$os" = "Ubuntu" ]] || [[ "$os" = "Debian" ]] || [[ "$os" = "Linux" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@
 ##
 #################################################################################
 
-install_opts="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email adm_passwd new_web_duser new_web_duser_email usr_passwd your_company installation_key relative_path new_web_dir web_user" 
+install_opts="db_host db_root_id db_root_pass db_user db_pass db_name new_web_admin new_web_admin_email new_web_admin_passwd new_web_duser new_web_duser_email new_web_duser_passwd your_company installation_key relative_path new_web_dir web_user" 
 upgrade_opts="web_dir relative_path";
 
 function show_help {
@@ -1226,7 +1226,7 @@ fi
 
 function AuthKeyURI()
 {
-	relpath=$relative_path
+	relpath=$(echo $relative_path | sed -e 's/[\/&]/\\&/g')
 	# trim extra char if exists
         install_key=$(echo $install_key|awk {'print $1'})
 	# check if changes were made in shell scripts via sed

--- a/install.sh
+++ b/install.sh
@@ -493,13 +493,13 @@ function EnableSSL()
         if [ "$new_relative_path" != "$relative_path" ] && [ "$new_relative_path" != "" ]; then
                 relative_path="$new_relative_path"
         fi
-        if [ "${new_relative_path:LEN}" != "/" ]; then
+        if [ "${new_relative_path: -1}" != "/" ]; then
                 new_relative_path=$new_relative_path"/"
         fi
         if [ "$new_web_dir" != "$web_dir" ] && [ "$new_web_dir" != "" ]; then
                 web_dir="$new_web_dir"
         fi
-        if [ "${web_dir:LEN}" != "/" ]; then
+        if [ "${web_dir: -1}" != "/" ]; then
                 web_dir=$web_dir"/"
         fi
 	if [[ $(grep "$ssl_path/certs/ca.crt" /etc/$web_service/conf.d/patch_manager.conf) = "" ]]; then
@@ -961,13 +961,13 @@ function WebUIInfo()
 	if [ "$new_relative_path" != "$relative_path" ] && [ "$new_relative_path" != "" ]; then
         	relative_path="$new_relative_path"
 	fi
-	if [ "${new_relative_path:LEN}" != "/" ]; then
+	if [ "${new_relative_path: -1}" != "/" ]; then
         	new_relative_path=$new_relative_path"/"
 	fi
 	if [ "$new_web_dir" != "$web_dir" ] && [ "$new_web_dir" != "" ]; then
         	web_dir="$new_web_dir"
 	fi
-	if [ "${web_dir:LEN}" != "/" ]; then
+	if [ "${web_dir: -1}" != "/" ]; then
         	web_dir=$web_dir"/"
 	fi
 	# Get apache daemon ID
@@ -1061,13 +1061,13 @@ function WebUIInfoUpdate()
         if [ "$new_relative_path" != "$relative_path" ] && [ "$new_relative_path" != "" ]; then
                 relative_path="$new_relative_path"
         fi
-        if [ "${new_relative_path:LEN}" != "/" ]; then
+        if [ "${new_relative_path: -1}" != "/" ]; then
                 new_relative_path=$new_relative_path"/"
         fi
         if [ "$new_web_dir" != "$web_dir" ] && [ "$new_web_dir" != "" ]; then
                 web_dir="$new_web_dir"
         fi
-        if [ "${web_dir:LEN}" != "/" ]; then
+        if [ "${web_dir: -1}" != "/" ]; then
                 web_dir=$web_dir"/"
         fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1751,6 +1751,9 @@ if [ "$UNATTENDED" = "YES" ]; then
 			
 			[ ! -f /root/.ssh/id_rsa ] &&  { echo "There needs to be an id_rsa key in /root/.ssh/id_rsa."; exit 1; }
 			
+			[ "${relative_path: -1}" != "/" ] && relative_path=$relative_path"/"
+			[ "${new_web_dir: -1}" != "/" ] && new_web_dir=$new_web_dir"/"
+			
 			OSCheckUnattended
 			dbConnTest root
 			[[ "$dbConnx" == "yes" ]] || { echo "Could not connect to the database."; exit 1; }

--- a/install.sh
+++ b/install.sh
@@ -95,12 +95,6 @@ if [ "$user" != "root" ]; then
 	exit 0
 fi
 
-# create keypair for root
-if [ ! -f /root/.ssh/id_rsa ]; then
-	echo -e "\n\e[32mNotice\e[0m: Creating pub/private keys for $user."
-	ssh-keygen -f /root/.ssh/id_rsa -t rsa -N ''
-	echo -e "\e[32mNotice\e[0m: Keypair created.\n"
-fi
 
 # get OS information and run applicable function
 if [[ -f /etc/lsb-release && -f /etc/debian_version ]]; then
@@ -1754,6 +1748,9 @@ if [ "$UNATTENDED" = "YES" ]; then
 			for var in $config_keys; do
 				[[ -z "$(eval echo \$$var)" ]] && { echo "Parameter --$(echo $var | sed 's,_,-,g') was required but not set"; exit 1; }
 			done
+			
+			[ ! -f /root/.ssh/id_rsa ] &&  { echo "There needs to be an id_rsa key in /root/.ssh/id_rsa."; exit 1; }
+			
 			OSCheckUnattended
 			dbConnTest root
 			[[ "$dbConnx" == "yes" ]] || { echo "Could not connect to the database."; exit 1; }
@@ -1788,6 +1785,14 @@ if [ "$UNATTENDED" = "YES" ]; then
 			;;
 	esac
 else
+
+	# create keypair for root
+	if [ ! -f /root/.ssh/id_rsa ]; then
+		echo -e "\n\e[32mNotice\e[0m: Creating pub/private keys for $user."
+		ssh-keygen -f /root/.ssh/id_rsa -t rsa -N ''
+		echo -e "\e[32mNotice\e[0m: Keypair created.\n"
+	fi
+
 	# run ask menu for update or install
 	mainMenu
 fi

--- a/install.sh
+++ b/install.sh
@@ -757,7 +757,7 @@ function dbCheck()
 
 function dbConnTest()
 {
-    # check connection to db
+        # check connection to db
 	if [[ "$1" == "root" ]]; then
         db_connx=$(mysql --batch -u $db_root_id -p"$db_root_pass" -h $db_host -e ";" > /dev/null; echo "$?")
 	else
@@ -1476,6 +1476,7 @@ function NewInstall()
 {
 	# run new install
 	echo -e "\n\e[32mMode\e[0m: Running new install\n"
+
 	# run DB functions
 	echo -e "\e[36m# Database Setup information\n\e[0m"
 	dbAskHost
@@ -1486,6 +1487,7 @@ function NewInstall()
 	dbUserDBCreate
 	dbConnTest
 	dbCheck
+
 	# check database connection from user provided details
 	if [[ "$dbConnx" = "no" ]]; then
         	echo -e "\n\e[31mError\e[0m: Unable to connect to: \e[36m$db_host\e[0m, please try again.\n"
@@ -1505,6 +1507,7 @@ function NewInstall()
 		echo -e "\n\e[32mNotice\e[0m: \e[36m$db_name\e[0m does not exist, creating as new."
 		dbCreate
 	fi
+
 	# Ask web information
 	echo -e "\n\e[36m# Webpage Location, User and Admin information.\e[0m\n"
 	WebUIInfo
@@ -1522,7 +1525,6 @@ function NewInstall()
 	# end install
         exit 0
 }
-
 
 function UpdateUpgrade()
 {
@@ -1767,10 +1769,10 @@ if [ "$UNATTENDED" = "YES" ]; then
 			else
 				echo -e "\n\e[32mNotice\e[0m: \e[36m$db_name\e[0m does not exist, creating as new."
 				dbCreate
-			fi			
+			fi
 
 			dbUserCreate
-			
+
 			# Create Company entries in database
 			dbCompCreate
 			# Add crontab entry for every 2 hours


### PR DESCRIPTION
Hi,

at the current state, the setup process is very interactive and makes active changes in the target system. 

This makes it absolutely unusable for an unattended installation via chief/puppet/saltstack/ansible.

In this PR, I am trying to offer a second installation option that

* does not install any packages or change configuration of existing packages
* has no interaction, but receives all configuration options either per environment variable or command line argument

This is far from usable or finished, but I wanted to know your opinon on this. (I haven't even tried to run it so far.)

Do you like the direction I am going with this? Should I do something differently? Should I drop it completely?

Your feedback please.