### PR TITLE
Client installer misleading error message

### DIFF
--- a/html/client/client_installer.php
+++ b/html/client/client_installer.php
@@ -11,7 +11,7 @@ $SERVER_URI = $protocol.$_SERVER['HTTP_HOST'].BASE_PATH;
 $script = "#!/bin/bash
 user=$(whoami)
 if [ \"\$user\" != \"root\" ]; then
-	echo -e \"You need to be root to run the installer.\nPlease run this: sudo curl ${SERVER_URI}client/client-installer.php|bash\"
+	echo -e \"You need to be root to run the installer.\nPlease run this: curl ${SERVER_URI}client/client-installer.php|sudo bash\"
 fi
 ls /opt/patch_manager/db.conf > /dev/null 2>&1
 if [[ \"$?\" = \"0\" ]]; then 


### PR DESCRIPTION
Using sudo on curl won't pass root privileges to the piped process.
You need to use sudo on bash instead.