### PR TITLE
fix variable not reset

### DIFF
--- a/html/plugins/main/patch_list.inc.php
+++ b/html/plugins/main/patch_list.inc.php
@@ -52,7 +52,7 @@ if (!isset($index_check) || $index_check != "active"){
                         $bug = end($url_array);
                         $url = "<td><a href='$bug_url' style='color:black'>Launchpad Bug #$bug</a></td>";
                 }
-        }
+        } else { $url = "<td>&nbsp;</td>"; }
      if (in_array($urgency,array('high','emergency'))){
                 $urgency = "<td style='color:red'><a href='http://www.ubuntuupdates.org/package/core/trusty/main/updates/$package_name_orig' style='color:red' target='_blank'>$urgency</a></td>";
      }


### PR DESCRIPTION
it took me a while to notice it, but when an item from the `patches` table has no `bug_url`, then the page listing patches will re-use the URL from the last item displayed that had one.
This can be avoided by making sure the `$url` variable is always set, whatever `if` we end up in.