### PR TITLE
Updating Debian/Ubuntu packages (1/2)

### DIFF
--- a/database/db_create.sql
+++ b/database/db_create.sql
@@ -47,8 +47,8 @@ CREATE TABLE `distro` (
   KEY `ix_distro_name` (`distro_name`),
   KEY `ix_icon_path` (`icon_path`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
-INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(1,'Ubuntu','img/icon/ubuntu.png','apt-get -y install');
-INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(2,'Debian','img/icon/debian.png','apt-get -y install');
+INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(1,'Ubuntu','img/icon/ubuntu.png','DEBIAN_FRONTEND=noninteractive apt-get -y install');
+INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(2,'Debian','img/icon/debian.png','DEBIAN_FRONTEND=noninteractive apt-get -y install');
 INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(3,'Fedora','img/icon/fedora.png','yum -y install');
 INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(4,'CentOS','img/icon/centos.png','yum -y install');
 INSERT IGNORE INTO distro(id,distro_name,icon_path,upgrade_command) VALUES(5,'RHEL','img/icon/rhel.png','yum -y install');


### PR DESCRIPTION
Setting `DEBIAN_FRONTEND=noninteractive`, prevents dpkg or apt from waiting for input.