### PR TITLE
fix(check-in): version

### DIFF
--- a/html/client/check-in.sh
+++ b/html/client/check-in.sh
@@ -10,7 +10,7 @@ fi
 # get OS info and version
 if [[ -f /etc/lsb-release && -f /etc/debian_version ]]; then
         export client_os=$(lsb_release -s -d|head -1|awk {'print $1'})
-        export client_os_ver=$(lsb_release -s -d|head -1|awk {'print $2'}|cut -d "." -f 1)
+        export client_os_ver=$(lsb_release -r|head -1|awk {'print $2'}|cut -d "." -f 1)
 elif [[ -f /etc/debian_version ]]; then
         export client_os="$(cat /etc/issue|head -n 1|awk {'print $1'})"
         export client_os_ver="$(cat /etc/debian_version|head -1|awk {'print $1'}|cut -d "." -f 1)"


### PR DESCRIPTION
When lsb-release is installed on a Debian (or Devuan), client_os_ver is set to GNU/Linux, whereas on Ubuntu that command returns with 14, 16, ...
Instead of querying lsb-release for a short description, we should look for the release number. Then, Debian version is set to 7, 8, ... Devuan gives 1, while Ubuntu still returns 14, 16, ...